### PR TITLE
Add `manage_groups` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ creation.
 Create a local user by providing at a minimum the user name, state, comment,
 groups, and initial password:
 
-    local_user { 'username':
+    local_user { 'rnelson':
       state            => 'present',
-      comment          => 'Real Name',
-      groups           => ['group1', 'group2'],
+      comment          => 'Rob Nelson',
+      groups           => ['rnelson0', 'wheel'],
       password         => 'encryptedstring',
     }
 
@@ -35,14 +35,14 @@ You may also provide the shell, home directory, password max age, the last
 change date (YYYY-MM-DD or number of days since Jan 1, 1970), and an array of ssh keys. These values
 default to /bin/bash, /home/<username>, 90 days, 0 days, and null, respectively.
 
-    local_user { 'username':
+    local_user { 'rnelson':
       state            => 'present',
       shell            => '/bin/bash',
-      home             => '/home/username',
+      home             => '/home/rnelson0',
       managehome       => true,
-      comment          => 'Real Name',
-      groups           => ['group1', 'group2'],
-      gid              => 'primary_group'
+      comment          => 'Rob Nelson',
+      groups           => ['rnelson0', 'wheel'],
+      gid              => 'rnelson0'
       last_change      => '2015-01-01',
       password         => 'encryptedstring',
       password_max_age => 90,
@@ -51,3 +51,9 @@ default to /bin/bash, /home/<username>, 90 days, 0 days, and null, respectively.
 
 Note: The encrypted string is processed via sed using '/' seperators. You MUST
 escape any '/' characters.
+
+If the specified groups do not exist and or not created elsewhere in your catalog (or ordered incorrectly), you will receive errors preventing the user from being created.
+
+    Error: Could not create user rnelson0: Execution of '/usr/sbin/useradd -c Rob Nelson -g rnelson0 -G wheel -d /home/rnelson0 -s /bin/bash -m rnelson0' returned 6: useradd: group 'rnelson0' does not exist
+
+Set the parameter `manage_groups` to `true` and the groups will be managed and ordered within `local_user`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@
 #    password_max_age    => 90,
 #    last_change         => '2015-01-01',
 #    ssh_authorized_keys => ['ssh-rsa AAAA...123 user@host'],
+#    manage_groups       => true,
 #  }
 #
 # === Authors
@@ -38,6 +39,7 @@ define local_user (
   $home                = "/home/${name}",
   $managehome          = true,
   $ssh_authorized_keys = [],
+  $manage_groups       = false,
 ) {
   validate_string($name)
   validate_string($state)
@@ -58,6 +60,13 @@ define local_user (
     validate_string($gid)
     if ($uid) {
       validate_integer($uid)
+    }
+    if ($manage_groups) {
+      $managed_groups = [$groups, $gid]
+      group { $managed_groups:
+        ensure => present,
+        before => User[$name],
+      }
     }
     user { $name:
       ensure           => $state,

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -18,6 +18,27 @@ describe 'local_user', :type => :define do
       :groups           => ['group1', 'group2'],
       :password_max_age => 90,
     }) }
+    it { is_expected.not_to create_group('rnelson0') }
+  end
+
+  context 'managing groups' do
+    let (:params) do
+      {
+        :state         => 'present',
+        :comment       => 'Rob Nelson',
+        :groups        => ['group1', 'group2'],
+        :password      => 'encryptedstring',
+        :manage_groups => true,
+      }
+    end
+
+    it { is_expected.to create_user('rnelson0').with({
+      :comment          => 'Rob Nelson',
+      :groups           => ['group1', 'group2'],
+    }) }
+    it { is_expected.to create_group('rnelson0') }
+    it { is_expected.to create_group('group1') }
+    it { is_expected.to create_group('group2') }
   end
 
   context 'using full params' do
@@ -32,6 +53,7 @@ describe 'local_user', :type => :define do
         :password_max_age    => 120,
         :ssh_authorized_keys => ['ssh-rsa AAAA...zwE1 rsa-key-20141029'],
         :uid                 => 101,
+        :gid                 => 'group2',
       }
     end
 
@@ -44,6 +66,7 @@ describe 'local_user', :type => :define do
       :uid              => 101,
     }) }
     it { is_expected.to create_local_user__ssh_authorized_keys('ssh-rsa AAAA...zwE1 rsa-key-20141029') }
+    it { is_expected.not_to create_group('rnelson0') }
   end
 
   context 'with a valid date for last_change' do
@@ -58,6 +81,7 @@ describe 'local_user', :type => :define do
     end
 
     it { is_expected.to create_user('rnelson0') }
+    it { is_expected.not_to create_group('rnelson0') }
   end
 
   context 'with an invalid date for last_change' do


### PR DESCRIPTION
  Documentation includes sample
  Existing rspec tests ensure no groups are managed by default; new test ensures it is when `manage_groups` istrue.