### PR TITLE
Regex improvements

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,10 +88,10 @@ define local_user (
 
     case $::osfamily {
       'RedHat':  {
-        $action = "/bin/sed -i -e 's/${name}:!!:/${name}:${password}:/g' /etc/shadow; chage -d ${last_change} ${name}"
+        $action = "/bin/sed -i -e 's/^${name}:!!:/${name}:${password}:/g' /etc/shadow; chage -d ${last_change} ${name}"
       }
       'Debian':  {
-        $action = "/bin/sed -i -e 's/${name}:x:/${name}:${password}:/g' /etc/shadow; chage -d ${last_change} ${name}"
+        $action = "/bin/sed -i -e 's/^${name}:x:/${name}:${password}:/g' /etc/shadow; chage -d ${last_change} ${name}"
       }
       default: { }
     }
@@ -99,7 +99,7 @@ define local_user (
     exec { "set ${name}'s password":
       command => $action,
       path    => '/usr/bin:/usr/sbin:/bin',
-      onlyif  => "egrep -q  -e '${name}:!!:' -e '${name}:x:' /etc/shadow",
+      onlyif  => "egrep -q -e '^${name}:!!:' -e '^${name}:x:' /etc/shadow",
       require => User[$name],
     }
   }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -19,6 +19,7 @@ describe 'local_user', :type => :define do
       :password_max_age => 90,
     }) }
     it { is_expected.not_to create_group('rnelson0') }
+    it { is_expected.to create_exec("set rnelson0's password") }
   end
 
   context 'managing groups' do


### PR DESCRIPTION
  Ensure the entire name is matched, to prevent partial or duplicate matches.
  Test for the exec's presence.

Fixes #9 