### PR TITLE
Default the comment field to resource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,12 @@ creation.
 
 ### Resource Definition
 
-Create a local user by providing at a minimum the user name, state, comment,
+Create a local user by providing at a minimum the user name, state,
 groups, and initial password:
 
     local_user { 'rnelson':
       state            => 'present',
-      comment          => 'Rob Nelson',
-      groups           => ['rnelson0', 'wheel'],
+      groups           => ['group1', 'group2'],
       password         => 'encryptedstring',
     }
 
@@ -105,4 +104,3 @@ If the specified groups do not exist and or not created elsewhere in your catalo
 
     Error: Could not create user rnelson0: Execution of '/usr/sbin/useradd -c Rob Nelson -g rnelson0 -G wheel
     -d /home/rnelson0 -s /bin/bash -m rnelson0' returned 6: useradd: group 'rnelson0' does not exist
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,9 +28,9 @@
 #
 define local_user (
   $state,
-  $comment,
   $groups,
   $password,
+  $comment             = $name,
   $uid                 = undef,
   $gid                 = $name,
   $last_change         = 0,

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -4,7 +4,6 @@ describe 'local_user', :type => :define do
   let (:params) do
     {
       :state    => 'present',
-      :comment  => 'Rob Nelson',
       :groups   => ['group1', 'group2'],
       :password => 'encryptedstring',
     }
@@ -12,7 +11,7 @@ describe 'local_user', :type => :define do
 
   context 'using minimum params' do
     it { is_expected.to create_user('rnelson0').with({
-      :comment          => 'Rob Nelson',
+      :comment          => 'rnelson0',
       :shell            => '/bin/bash',
       :home             => '/home/rnelson0',
       :groups           => ['group1', 'group2'],


### PR DESCRIPTION
The preserves the comment field as a parameter, provides data to fill it, and allows it to pass as a non-default. Additionally, we could add "Managed by Puppet" in the comment field. 