### PR TITLE
Initial Commit - Create a Windows user

### DIFF
--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -1,0 +1,60 @@
+# Local User - Windows Edition
+#
+# DESCRIPTION:
+# WIP - Allows you to set local users and RDP access via Puppet (for now...)
+#  
+# USAGE: 
+# local_user::windows { 'steve' :
+#   state     => present|absent, # currently set to present or absent
+#   password  => <your password>, # a plain text password
+#   comment   => "Full Name", # user's full name
+#   groups    => <string or array of groups>, # add user to groups
+#   allow_rdp => true|false,  # grant user rdp access
+#   admin     => true|false,  # add user to Administrators group
+# }
+#
+# local_user::windows { 'bob' :
+#   state     => present,
+#   password  => 'Bobbo1234',
+#   groups    => ['Administrators'],
+#   comment   => 'Bob is Cool',
+#   allow_rdp => true,
+# }
+
+define local_user::windows (
+  $state,
+  $password,
+  $groups = [],
+  $admin = false,
+  $comment = $name,
+  $allow_rdp = true,
+) {
+
+  if $::kernel != 'windows' {
+    fail('Windows support only!')
+  }
+
+  # With default params, users receive RDP access
+  if $admin == false and $allow_rdp == true {
+    $group_array = ['Remote Desktop Users']
+  }
+  if $admin == true and $allow_rdp == true {
+    $group_array = ['Administrators', 'Remote Desktop Users']
+  }
+  if $admin == true and $allow_rdp == false {
+    $group_array = ['Administrators']
+  }
+  if $admin == false and $allow_rdp == false {
+    $group_array = []
+  }
+  
+  $grouplist = concat($groups,$group_array)
+
+  user { $name:
+      ensure   => $state,
+      comment  => $comment,
+      groups   => $grouplist,
+      password => $password,
+  }
+
+}

--- a/spec/defines/windows_spec.rb
+++ b/spec/defines/windows_spec.rb
@@ -1,0 +1,140 @@
+require 'spec_helper'
+describe 'local_user::windows', :type => :define do
+  let (:title) { 'rnelson0' }
+  let (:params) do
+    {
+      :state    => 'present',
+      :groups   => [],
+      :password => 'Microsoft1',
+    }
+  end
+  let (:facts) do
+    {
+      :kernel => "windows",
+    }
+  end
+
+  context 'with defaults' do
+    it { is_expected.to create_user('rnelson0').with({
+      :comment          => 'rnelson0',
+      :groups           => ['Remote Desktop Users'],
+      :password         => 'Microsoft1'
+    }) }
+  end
+  
+  context 'with allow_rdp => false, admin => false, no groups' do
+    let (:params) do
+      {
+        :state     => 'present',
+        :groups    => [],
+        :password  => 'Microsoft1',
+        :admin     => false,
+        :allow_rdp => false,
+      }
+    end
+
+    it { is_expected.to create_user('rnelson0').with({
+      :comment  => 'rnelson0',
+      :groups   => [],
+      :password => 'Microsoft1',
+      })}
+  end
+
+  context 'with allow_rdp => true, admin => true, no groups' do
+    let (:params) do
+      {
+        :state     => 'present',
+        :password  => 'Microsoft1',
+        :admin     => true,
+        :allow_rdp => true,
+      }
+    end
+
+    it { is_expected.to create_user('rnelson0').with({
+      :comment  => 'rnelson0',
+      :groups   => ['Administrators','Remote Desktop Users'],
+      :password => 'Microsoft1',
+      })}
+  end
+
+  context 'with allow_rdp => false, admin > true, no groups' do
+    let (:params) do
+      {
+        :state     => 'present',
+        :password  => 'Microsoft1',
+        :admin     => true,
+        :allow_rdp => false,
+      }
+    end
+
+    it { is_expected.to create_user('rnelson0').with({
+      :comment  => 'rnelson0',
+      :groups   => ['Administrators'],
+      :password => 'Microsoft1',
+      })}
+  end
+
+  context 'with allow_rdp => false, admin => true, rnelson0 group' do
+    let (:params) do
+      {
+        :state     => 'present',
+        :groups    => ['rnelson0'],
+        :password  => 'Microsoft1',
+        :admin     => true,
+        :allow_rdp => false,
+      }
+    end
+
+    it { is_expected.to create_user('rnelson0').with({
+      :comment  => 'rnelson0',
+      :groups   => ['rnelson0','Administrators'],
+      :password => 'Microsoft1',
+      })}
+  end
+
+  context 'with allow_rdp => true, admin => true, rnelson0 group' do
+    let (:params) do
+      {
+        :state     => 'present',
+        :groups    => ['rnelson0'],
+        :password  => 'Microsoft1',
+        :admin     => true,
+        :allow_rdp => true,
+      }
+    end
+
+    it { is_expected.to create_user('rnelson0').with({
+      :comment  => 'rnelson0',
+      :groups   => ['rnelson0','Administrators','Remote Desktop Users'],
+      :password => 'Microsoft1',
+      })}
+  end
+
+  context 'with allow_rdp => false, admin => true, rnelson0 group' do
+    let (:params) do
+      {
+        :state     => 'present',
+        :groups    => ['rnelson0'],
+        :password  => 'Microsoft1',
+        :admin     => false,
+        :allow_rdp => false,
+      }
+    end
+
+    it { is_expected.to create_user('rnelson0').with({
+      :comment  => 'rnelson0',
+      :groups   => ['rnelson0'],
+      :password => 'Microsoft1',
+      })}
+  end
+
+  context 'fail on non-windows systems' do
+    let (:facts) do
+      {
+        :kernel => "Linux",
+      }
+    end
+    it { is_expected.to compile.and_raise_error(/Windows support only!/) }
+  end
+  
+end


### PR DESCRIPTION
First pass for the windows user.  I added parameters for admin/rdp since
in the *majority* of use cases I've seen those are usually the two local
groups anyone ever cares about.