### PR TITLE
Expose system parameter for user type

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,7 @@ define local_user (
   $managehome          = true,
   $ssh_authorized_keys = [],
   $manage_groups       = false,
+  $system              = false,
 ) {
   validate_string($name)
   validate_string($state)
@@ -58,6 +59,7 @@ define local_user (
     validate_integer($password_max_age)
     validate_string($home)
     validate_string($gid)
+    validate_bool($system)
     if ($uid) {
       validate_integer($uid)
     }
@@ -95,6 +97,7 @@ define local_user (
       password_max_age => $password_max_age,
       uid              => $uid,
       gid              => $gid,
+      system           => $system,
     }
     if ($ssh_authorized_keys) {
       local_user::ssh_authorized_keys{$ssh_authorized_keys:

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -9,7 +9,7 @@ describe 'local_user', :type => :define do
     }
   end
 
-  let (:facts) do 
+  let (:facts) do
     {
       :osfamily => 'Debian',
     }
@@ -112,6 +112,7 @@ context 'manage_groups with invalid input' do
         :ssh_authorized_keys => ['ssh-rsa AAAA...zwE1 rsa-key-20141029'],
         :uid                 => 101,
         :gid                 => 'group2',
+        :system              => true,
       }
     end
 
@@ -122,6 +123,7 @@ context 'manage_groups with invalid input' do
       :groups           => ['group1', 'group2'],
       :password_max_age => 120,
       :uid              => 101,
+      :system           => true
     }) }
     it { is_expected.to create_local_user__ssh_authorized_keys('ssh-rsa AAAA...zwE1 rsa-key-20141029') }
     it { is_expected.not_to create_group('rnelson0') }


### PR DESCRIPTION
Exposes the `system` parameter when creating a user, default to `false`. Useful when defining a system user with low-numbered GID but unable to predict what GIDs are free to assign.