### PR TITLE
Remove duplicate groups when assigning both gid and groups

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,7 +66,7 @@ define local_user (
       #Set groups to check for
       case $manage_groups {
         true, 'enabled':  {
-          $managed_groups = [$groups, $gid]
+          $managed_groups = unique([$groups, $gid])
         }
         'primary','gid':  {
           $managed_groups = [$gid]


### PR DESCRIPTION
A user may attempt to assign the gid in the groups array. This patch uses stdlib's `unique()` to ensure the duplicate group gets removed before the `create_resources()` call.