### PR TITLE
Pass password through to puppet directly rather than sed /etc/shadow

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ This example is functionally equivalent to the second [Resource Definition](#res
 
 * When no `$comment` is provided, the comment field will contain the username.
 
-* The encrypted string is processed via sed using '/' seperators. You MUST escape any '/' characters.
-
 * If the specified groups do not exist and or not created elsewhere in your catalog (or ordered incorrectly), you will receive errors preventing the user from being created. Set the parameter `manage_groups` to `true` and the groups will be managed and ordered within `local_user`. The error looks like:
 ````
 Error: Could not create user rnelson0: Execution of '/usr/sbin/useradd -c Rob Nelson -g rnelson0 -G wheel

--- a/lib/facter/linux_users.rb
+++ b/lib/facter/linux_users.rb
@@ -1,0 +1,21 @@
+if Facter.value(:kernel) == 'Linux'
+  mutex = Mutex.new
+
+  # We store a list of users which are not an essential systems users here ...
+  users = []
+
+  Puppet::Type.type('user').instances.each do |user|
+    # Get details about the user from the corresponding instance ...
+    instance = user.retrieve
+
+    mutex.synchronize do
+      # Add user to list only if the user is not an essential system user ...
+      users << user.name unless instance[user.property(:uid)].to_i < 1000
+    end
+  end
+
+  Facter.add('linux_users') do
+    confine :kernel => :linux
+    setcode { users.sort.join(',') }
+  end
+end

--- a/lib/facter/linux_users.rb
+++ b/lib/facter/linux_users.rb
@@ -10,7 +10,7 @@ if Facter.value(:kernel) == 'Linux'
 
     mutex.synchronize do
       # Add user to list only if the user is not an essential system user ...
-      users << user.name unless instance[user.property(:uid)].to_i < 1000
+      users << user.name
     end
   end
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@
 define local_user (
   $state,
   $groups,
-  $password            = '*',
+  $password,
   $comment             = $name,
   $uid                 = undef,
   $gid                 = $name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@
 define local_user (
   $state,
   $groups,
-  $password,
+  $password            = '*',
   $comment             = $name,
   $uid                 = undef,
   $gid                 = $name,
@@ -87,18 +87,35 @@ define local_user (
       }
     }
 
-    user { $name:
-      ensure           => $state,
-      shell            => $shell,
-      home             => $home,
-      comment          => $comment,
-      managehome       => $managehome,
-      groups           => $groups,
-      password_max_age => $password_max_age,
-      uid              => $uid,
-      gid              => $gid,
-      system           => $system,
+    if ($name in $::linux_users) {
+        user { $name:
+          ensure           => $state,
+          shell            => $shell,
+          home             => $home,
+          comment          => $comment,
+          managehome       => $managehome,
+          groups           => $groups,
+          password_max_age => $password_max_age,
+          uid              => $uid,
+          gid              => $gid,
+          system           => $system,
+        }
+    } else {
+        user { $name:
+          ensure           => $state,
+          shell            => $shell,
+          home             => $home,
+          comment          => $comment,
+          managehome       => $managehome,
+          groups           => $groups,
+          password_max_age => $password_max_age,
+          password         => $password,
+          uid              => $uid,
+          gid              => $gid,
+          system           => $system,
+        }
     }
+
     if ($ssh_authorized_keys) {
       local_user::ssh_authorized_keys{$ssh_authorized_keys:
         user => $name,
@@ -106,22 +123,6 @@ define local_user (
       User[$name] -> Local_user::Ssh_authorized_keys[$ssh_authorized_keys]
     }
 
-    case $::osfamily {
-      'RedHat':  {
-        $action = "/bin/sed -i -e 's/^${name}:!!:/${name}:${password}:/g' /etc/shadow; chage -d ${last_change} ${name}"
-      }
-      'Debian':  {
-        $action = "/bin/sed -i -e 's/^${name}:x:/${name}:${password}:/g' /etc/shadow; chage -d ${last_change} ${name}"
-      }
-      default: { }
-    }
-
-    exec { "set ${name}'s password":
-      command => $action,
-      path    => '/usr/bin:/usr/sbin:/bin',
-      onlyif  => "egrep -q -e '^${name}:!!:' -e '^${name}:x:' /etc/shadow",
-      require => User[$name],
-    }
   }
 
 }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -5,13 +5,14 @@ describe 'local_user', :type => :define do
     {
       :state    => 'present',
       :groups   => ['group1', 'group2'],
-      :password => 'encryptedstring',
+#      :password => 'encryptedstring',
     }
   end
 
   let (:facts) do
     {
-      :osfamily => 'Debian',
+      :osfamily    => 'Debian',
+      :linux_users => ['nobody'],
     }
   end
 
@@ -22,9 +23,9 @@ describe 'local_user', :type => :define do
       :home             => '/home/rnelson0',
       :groups           => ['group1', 'group2'],
       :password_max_age => 90,
+      :password         => '*',
     }) }
     it { is_expected.not_to create_group('rnelson0') }
-    it { is_expected.to create_exec("set rnelson0's password") }
   end
 
   context 'managing all groups' do
@@ -122,6 +123,7 @@ context 'manage_groups with invalid input' do
       :home             => '/nfshome/rnelson0',
       :groups           => ['group1', 'group2'],
       :password_max_age => 120,
+      :password         => 'encryptedstring',
       :uid              => 101,
       :system           => true
     }) }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -5,7 +5,7 @@ describe 'local_user', :type => :define do
     {
       :state    => 'present',
       :groups   => ['group1', 'group2'],
-#      :password => 'encryptedstring',
+      :password => 'encryptedstring',
     }
   end
 
@@ -23,7 +23,7 @@ describe 'local_user', :type => :define do
       :home             => '/home/rnelson0',
       :groups           => ['group1', 'group2'],
       :password_max_age => 90,
-      :password         => '*',
+      :password         => 'encryptedstring',
     }) }
     it { is_expected.not_to create_group('rnelson0') }
   end


### PR DESCRIPTION
Using sed on the /etc/shadow file limits what distributions this module can successfully set a password on (for example,  on my Ubuntu 16.04 test system, it could not).  This PR adds a fact which forms a list of all linux users with a UID over 1000 (non-system users).  If the user does not exist already, the user resource sends a password attribute, and if the user does already exist, then it does not submit a password attribute.

This makes the module much more distribution agnostic while preserving the ability for users to manage their own passwords.
